### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BACnet Proxy Agent
 
-![Passing?](https://github.com/eclipse-volttron/volttron-bacnet-proxy/actions/workflows/run-tests.yml/badge.svg)
+[![Passing?](https://github.com/eclipse-volttron/volttron-bacnet-proxy/actions/workflows/run-tests.yml/badge.svg)](https://github.com/eclipse-volttron/volttron-bacnet-proxy/actions/workflows/run-tests.yml)
 [![pypi version](https://img.shields.io/pypi/v/volttron-bacnet-proxy.svg)](https://pypi.org/project/volttron-bacnet-proxy/)
 
 BACnet Proxy is an agent that supports communication and management of BACnet devices.
@@ -43,19 +43,19 @@ python -m venv env
 source env/bin/activate
 ```
 
-Installing volttron-platform-driver requires a running volttron instance.
+Installing volttron-platform-driver requires a running volttron instance. Install volttron and start an instance in the background and save log output to a file named 'volttron.log'
 
 ```shell
 pip install volttron
-
-# Start platform with output going to volttron.log
 volttron -vv -l volttron.log &
 ```
 
 Install and start the BACnet proxy agent.
 
 ```shell
-vctl install volttron-bacnet-proxy --agent-config <path to bacnet proxy config file> --start
+vctl install volttron-bacnet-proxy --agent-config <path to bacnet proxy config file> \
+--vip-identity platform.bacnet_proxy \
+--start
 ```
 
 View the status of the installed agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
     "Intended Audience :: Other Audience",
     "License :: OSI Approved :: Apache Software License"
 ]
+include = ["IDENTITY"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
@@ -53,7 +54,7 @@ coverage = "^6.3.2"
 isort = "^5.10.1"
 pytest-sugar = "^0.9.6"
 
-[tool.poetry.group.documentation.dependencies]
+[tool.poetry.group.docs.dependencies]
 Sphinx = "^4.5.0"
 sphinx-rtd-theme = "^1.0.0"
 


### PR DESCRIPTION
* Update README to ensure that bacnet proxy is installed so that it can be used with bacnet driver
* Adds 'IDENTITY' as part of package, however, 'IDENTITY' is still not picked up by 'volttron-core' because of [this issue](https://github.com/eclipse-volttron/volttron-core/issues/119)
